### PR TITLE
Not all envFrom configurations were loading properly

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The Business Partner Agent allows to manage and exchange master data between organizations.
 type: application
 
-version: 0.4.0-alpha09
+version: 0.4.0-alpha10
 appVersion: sha-86b02ee6
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -269,12 +269,12 @@ If Keycloak is enabled, add the client id and secret from the keycloak secret to
 
 {{/*
 If Keycloak is enabled, mount the keycloak config map as env vars
+We don't need envFrom because we always load application configmap...
 */}}
 {{- define "bpa.keycloak.configmap.env.vars" -}}
 {{- if (.Values.keycloak.enabled) -}}
-envFrom:
-  - configMapRef:
-      name: {{ template "bpa.fullname" . }}-keycloak
+- configMapRef:
+    name: {{ template "bpa.fullname" . }}-keycloak
 {{- end -}}
 {{- end -}}
 

--- a/charts/bpa/templates/bpa_deployment.yaml
+++ b/charts/bpa/templates/bpa_deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 -Dbpa.pg.password=$(POSTGRES_PASSWORD)
                 -Dmicronaut.config.files={{ include "bpa.config.files" . }}
             {{- include "bpa.application.configmap.env.vars" . | nindent 10}}
-            {{- include "bpa.keycloak.configmap.env.vars" . | nindent 10}}
+            {{- include "bpa.keycloak.configmap.env.vars" . | nindent 12}}
           {{- include "bpa.schemas.volume.mount" . | nindent 10}}
           resources:
             {{- toYaml .Values.bpa.resources | nindent 12 }}


### PR DESCRIPTION
Ran in Openshift, and it wasn't loading the BPA application config map env. vars if Keycloak ConfigMap was loading. Had to tweak the helper to not include the second `envFrom` property. Just put all configmaps under a single `envFrom` property.