### PR TITLE
remove uniresolver url and did prefix from bpa

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The Business Partner Agent allows to manage and exchange master data between organizations.
 type: application
 
-version: 0.7.0-alpha01
+version: 0.7.0-alpha02
 appVersion: sha-ee1621b5
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
-![Version: 0.7.0-alpha01](https://img.shields.io/badge/Version-0.7.0--alpha01-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-ee1621b5](https://img.shields.io/badge/AppVersion-sha--ee1621b5-informational?style=flat-square)
+![Version: 0.7.0-alpha02](https://img.shields.io/badge/Version-0.7.0--alpha02-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-ee1621b5](https://img.shields.io/badge/AppVersion-sha--ee1621b5-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -72,7 +72,7 @@ Create a yaml file.
 ```yaml
 cat <<EOT >> values-mybpa.yaml
 acapy:
-  agentName: did:sov:idu:1234:agentname
+  agentName: did:sov:1234:agentname
   agentSeed: 12345678912345678912345678900011
   resources:
     requests:
@@ -83,13 +83,9 @@ bpa:
     bootstrap:
       password: changeme
       username: admin
-    did:
-      prefix: 'did:sov:idu:'
     ledger:
       browser: https://explorer.idu.network
     name: My BPA
-    resolver:
-      url: https://resolver.stage.economyofthings.io
   resources:
     requests:
       cpu: 100m
@@ -112,14 +108,14 @@ schemas:
       id: UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1
       label: Bank Account
       restrictions:
-      - issuerDid: did:sov:idu:UmZ25DANwS6ngGWB4ye4tN
+      - issuerDid: did:sov:UmZ25DANwS6ngGWB4ye4tN
         label: Demo Bank
     commercial-register:
       defaultAttributeName: companyName
       id: R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1
       label: Commercial Register
       restrictions:
-      - issuerDid: did:sov:idu:R6WR6n7CQVDjvvmwofHK6S
+      - issuerDid: did:sov:R6WR6n7CQVDjvvmwofHK6S
         label: Commercial Register
   enabled: true
 
@@ -231,7 +227,6 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.config.bootstrap.password | string | `"changeme"` |  |
 | bpa.config.bootstrap.username | string | `"admin"` |  |
 | bpa.config.creddef.revocationRegistrySize | int | `3000` |  |
-| bpa.config.did.prefixOverride | string | `""` | Will be otherwise calculated based on global.ledger config |
 | bpa.config.i18n.fallbackLocale | string | `"en"` |  |
 | bpa.config.i18n.locale | string | `"en"` |  |
 | bpa.config.imprint.enabled | bool | `false` |  |
@@ -240,7 +235,6 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.config.nameOverride | string | `""` | Override name shown in the frontend (may container whitespaces and so on). Default: Helm release name, capitalized |
 | bpa.config.privacyPolicy.enabled | bool | `false` |  |
 | bpa.config.privacyPolicy.urlOverride | string | `""` |  |
-| bpa.config.resolver.urlOverride | string | `""` |  |
 | bpa.config.scheme | string | `"https"` |  |
 | bpa.config.security.enabled | bool | `true` |  |
 | bpa.config.titleOverride | string | `""` | Override title shown in the browser tab. Default: Helm release name, capitalized (or NameOverride if given) |

--- a/charts/bpa/README.md.gotmpl
+++ b/charts/bpa/README.md.gotmpl
@@ -71,7 +71,7 @@ Create a yaml file.
 ```yaml
 cat <<EOT >> values-mybpa.yaml
 acapy:
-  agentName: did:sov:idu:1234:agentname
+  agentName: did:sov:1234:agentname
   agentSeed: 12345678912345678912345678900011
   resources:
     requests:
@@ -82,13 +82,9 @@ bpa:
     bootstrap:
       password: changeme
       username: admin
-    did:
-      prefix: 'did:sov:idu:'
     ledger:
       browser: https://explorer.idu.network
     name: My BPA
-    resolver:
-      url: https://resolver.stage.economyofthings.io
   resources:
     requests:
       cpu: 100m
@@ -111,14 +107,14 @@ schemas:
       id: UmZ25DANwS6ngGWB4ye4tN:2:BankAccount:0.1
       label: Bank Account
       restrictions:
-      - issuerDid: did:sov:idu:UmZ25DANwS6ngGWB4ye4tN
+      - issuerDid: did:sov:UmZ25DANwS6ngGWB4ye4tN
         label: Demo Bank
     commercial-register:
       defaultAttributeName: companyName
       id: R6WR6n7CQVDjvvmwofHK6S:2:commercialregister:0.1
       label: Commercial Register
       restrictions:
-      - issuerDid: did:sov:idu:R6WR6n7CQVDjvvmwofHK6S
+      - issuerDid: did:sov:R6WR6n7CQVDjvvmwofHK6S
         label: Commercial Register
   enabled: true
 

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -170,13 +170,6 @@ Return seed
 {{- end -}}
 
 {{/*
-Return didPrefix
-*/}}
-{{- define "acapy.didPrefix" -}}
-{{- get (dict "bosch-test" "did:sov:iil:" "idu" "did:sov:idu:") .Values.global.ledger -}}
-{{- end -}}
-
-{{/*
 Return acapy initialization call
 */}}
 {{- define "acapy.registerLedger" -}}

--- a/charts/bpa/templates/bpa_configmap.yaml
+++ b/charts/bpa/templates/bpa_configmap.yaml
@@ -2,7 +2,6 @@
 {{- $bpaIngressHost := include "bpa.host" . -}}
 {{- $acapyUrl := (printf "http://%s:%g" (include "acapy.fullname" .) (.Values.acapy.service.adminPort)) -}}
 {{- $acapyEndpoint := (printf "https://%s" ($acapyIngressHost)) -}}
-{{- $didPrefix := include "acapy.didPrefix" . -}} 
 {{- $agentName := include "business.partner.agent.name" . -}}
 {{- $browserTitle := include "business.partner.browser.title" . -}}
 apiVersion: v1
@@ -19,12 +18,10 @@ data:
   POSTGRESQL_HOST: {{ include "global.postgresql.fullname" . | quote }}
   POSTGRESQL_USER: {{ .Values.postgresql.postgresqlUsername | quote }}
   BPA_SECURITY_ENABLED: {{ .Values.bpa.config.security.enabled | quote }}
-  BPA_RESOLVER_URL: {{ .Values.bpa.config.resolver.urlOverride | default (printf "https://resolver%s" .Values.global.ingressSuffix) | quote }}
   BPA_LEDGER_BROWSER: {{ include "bpa.ledgerBrowser" . | quote }}
   BPA_HOST: {{ $bpaIngressHost | quote }}
   BPA_SCHEME: {{ .Values.bpa.config.scheme | quote }}
   BPA_WEB_MODE: {{ .Values.bpa.config.web.only | quote }}
-  BPA_DID_PREFIX: {{ .Values.bpa.config.did.prefixOverride | default $didPrefix | quote }}
   BPA_BOOTSTRAP_UN: {{ .Values.bpa.config.bootstrap.username | quote }}
   BPA_BOOTSTRAP_PW: {{ .Values.bpa.config.bootstrap.password | quote }}
   BPA_CREDDEF_REVOCATION_REGISTRY_SIZE: {{ .Values.bpa.config.creddef.revocationRegistrySize | quote }}

--- a/charts/bpa/values.schema.json
+++ b/charts/bpa/values.schema.json
@@ -217,7 +217,7 @@
                                     "type": "string",
                                     "title": "Username",
                                     "form": true
-                                }, 
+                                },
                                 "password": {
                                     "type": "string",
                                     "title": "Password",
@@ -237,17 +237,6 @@
                                 }
                             }
                         },
-                        "did": {
-                            "type": "object",
-                            "properties": {
-                                "prefixOverride": {
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "type": "string"
-                                }
-                            }
-                        },
                         "i18n": {
                             "type": "object",
                             "properties": {
@@ -255,7 +244,7 @@
                                     "type": "string"
                                 },
                                 "locale": {
-                                  "type": "string"
+                                    "type": "string"
                                 }
                             }
                         },
@@ -290,14 +279,6 @@
                                     "title": "Show policy page?",
                                     "form": true
                                 },
-                                "urlOverride": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "resolver": {
-                            "type": "object",
-                            "properties": {
                                 "urlOverride": {
                                     "type": "string"
                                 }

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -43,16 +43,11 @@ bpa:
     bootstrap:
       username: admin
       password: changeme
-    resolver:
-      urlOverride: ""
     ledger:
       browserUrlOverride: ""
     scheme: https
     web:
       only: false
-    did:
-      # -- Will be otherwise calculated based on global.ledger config
-      prefixOverride: ""
     creddef:
       revocationRegistrySize: 3000
     imprint:


### PR DESCRIPTION
Leftover work from the aca-py 0.7 migration. I did not want to change the chart for this, but micronaut has a special behavior that translates environment variables to system properties. So settings an environment variable like BPA_DID_PREFIX gets translated to/or behaves the same as -Dbpa.did.prefix Therefore I had to remove the uniresolver and prefix settings. Both are needed again in the future, but on the aca-py level. As the details are still somewhat in the working it is better to remove both properties anyway.

Signed-off-by: Philipp Etschel <philipp@etschel.net>