### PR TITLE
use aca-py 0.7.0rc1

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -4,7 +4,7 @@ description: The Business Partner Agent allows to manage and exchange master dat
 type: application
 
 version: 0.7.0-alpha05
-appVersion: sha-7beec350
+appVersion: sha-9141903f
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
 sources: ["https://github.com/hyperledger-labs/business-partner-agent-chart"]

--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -4,7 +4,7 @@ description: The Business Partner Agent allows to manage and exchange master dat
 type: application
 
 version: 0.7.0-alpha05
-appVersion: sha-5c5073f0
+appVersion: sha-7beec350
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
 sources: ["https://github.com/hyperledger-labs/business-partner-agent-chart"]

--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,8 +3,8 @@ name: bpa
 description: The Business Partner Agent allows to manage and exchange master data between organizations.
 type: application
 
-version: 0.7.0-alpha04
-appVersion: sha-3abcc49a
+version: 0.7.0-alpha05
+appVersion: sha-5c5073f0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
 sources: ["https://github.com/hyperledger-labs/business-partner-agent-chart"]

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
-![Version: 0.7.0-alpha05](https://img.shields.io/badge/Version-0.7.0--alpha05-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-5c5073f0](https://img.shields.io/badge/AppVersion-sha--5c5073f0-informational?style=flat-square)
+![Version: 0.7.0-alpha05](https://img.shields.io/badge/Version-0.7.0--alpha05-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-7beec350](https://img.shields.io/badge/AppVersion-sha--7beec350-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -260,8 +260,10 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.openshift.route.wildcardPolicy | string | `"None"` |  |
 | bpa.podAnnotations | object | `{}` |  |
 | bpa.podSecurityContext | object | `{}` |  |
-| bpa.resources.requests.cpu | string | `"100m"` |  |
-| bpa.resources.requests.memory | string | `"256Mi"` |  |
+| bpa.resources.limits.cpu | string | `"2"` |  |
+| bpa.resources.limits.memory | string | `"384Mi"` |  |
+| bpa.resources.requests.cpu | string | `"0.2"` |  |
+| bpa.resources.requests.memory | string | `"384Mi"` |  |
 | bpa.securityContext | object | `{}` |  |
 | bpa.service.port | int | `80` |  |
 | bpa.service.type | string | `"ClusterIP"` |  |

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
-![Version: 0.7.0-alpha05](https://img.shields.io/badge/Version-0.7.0--alpha05-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-7beec350](https://img.shields.io/badge/AppVersion-sha--7beec350-informational?style=flat-square)
+![Version: 0.7.0-alpha05](https://img.shields.io/badge/Version-0.7.0--alpha05-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-9141903f](https://img.shields.io/badge/AppVersion-sha--9141903f-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -182,7 +182,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.fullnameOverride | string | `""` |  |
 | acapy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | acapy.image.repository | string | `"bcgovimages/aries-cloudagent"` |  |
-| acapy.image.tag | string | `"py36-1.16-1_0.7.0rc0"` | Overrides the image tag whose default is the chart appVersion. |
+| acapy.image.tag | string | `"py36-1.16-1_0.7.0rc1"` | Overrides the image tag whose default is the chart appVersion. |
 | acapy.imagePullSecrets | list | `[]` |  |
 | acapy.ingress.annotations | object | `{}` |  |
 | acapy.ingress.enabled | bool | `true` |  |

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
-![Version: 0.7.0-alpha04](https://img.shields.io/badge/Version-0.7.0--alpha04-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-3abcc49a](https://img.shields.io/badge/AppVersion-sha--3abcc49a-informational?style=flat-square)
+![Version: 0.7.0-alpha05](https://img.shields.io/badge/Version-0.7.0--alpha05-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-5c5073f0](https://img.shields.io/badge/AppVersion-sha--5c5073f0-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -182,7 +182,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.fullnameOverride | string | `""` |  |
 | acapy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | acapy.image.repository | string | `"bcgovimages/aries-cloudagent"` |  |
-| acapy.image.tag | string | `"py36-1.16-0_0.7-pre.3"` | Overrides the image tag whose default is the chart appVersion. |
+| acapy.image.tag | string | `"py36-1.16-1_0.7.0rc0"` | Overrides the image tag whose default is the chart appVersion. |
 | acapy.imagePullSecrets | list | `[]` |  |
 | acapy.ingress.annotations | object | `{}` |  |
 | acapy.ingress.enabled | bool | `true` |  |

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -110,15 +110,12 @@ bpa:
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+    limits:
+      cpu: "2"
+      memory: 384Mi
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: "0.2"
+      memory: 384Mi
 
   nodeSelector: {}
 

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -217,7 +217,7 @@ acapy:
     repository: bcgovimages/aries-cloudagent
     pullPolicy: IfNotPresent
     # --  Overrides the image tag whose default is the chart appVersion.
-    tag: py36-1.16-1_0.7.0rc0
+    tag: py36-1.16-1_0.7.0rc1
 
   adminURLApiKey: 2f9729eef0be49608c1cffd49ee3cc4a
 

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -220,7 +220,7 @@ acapy:
     repository: bcgovimages/aries-cloudagent
     pullPolicy: IfNotPresent
     # --  Overrides the image tag whose default is the chart appVersion.
-    tag: py36-1.16-0_0.7-pre.3
+    tag: py36-1.16-1_0.7.0rc0
 
   adminURLApiKey: 2f9729eef0be49608c1cffd49ee3cc4a
 


### PR DESCRIPTION
Latest changes from bpa repo and memory limits.

Since Version 10 Java detects if it runs within a container and reads the memory size from `/sys/fs/cgroup/memory/memory.limit_in_byte` If no limits are set in the helm chart this will be the memory of the underlying physical machine. This is bad because over time memory will grow and the cluster will run out of memory. 

Signed-off-by: Philipp Etschel <philipp@etschel.net>