### PR TITLE
postgresql as optional dependency

### DIFF
--- a/charts/bpa/Chart.lock
+++ b/charts/bpa/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami/
   version: 10.16.2
-digest: sha256:7a3d4cf6efe0ebbaed8dfad6a9d3b0482c66e67c5af0d54445195835a24e71bc
-generated: "2022-03-15T12:29:38.727279+01:00"
+digest: sha256:a7587e626862bfc68a276b8504b5fac3e7181320b3b66ffa107c619dacae4a4a
+generated: "2022-03-16T11:45:54.05454+01:00"

--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The BPA allows organizations to verify, hold, and issue verifiable credentials.
 type: application
 
-version: 0.10.0
+version: 0.10.1
 appVersion: 0.10.0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
@@ -23,4 +23,3 @@ dependencies:
     version: 10.16.2
     repository: https://charts.bitnami.com/bitnami/
     condition: postgresql.enabled
-

--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -8,7 +8,6 @@ appVersion: 0.10.0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
 sources: ["https://github.com/hyperledger-labs/business-partner-agent-chart"]
-engine: gotpl
 maintainers:
   - email: Frank.Bernhardt@bosch.com
     name: frank-bee
@@ -23,4 +22,5 @@ dependencies:
   - name: postgresql
     version: 10.16.2
     repository: https://charts.bitnami.com/bitnami/
-    condition: persistence.deployPostgres
+    condition: postgresql.enabled
+

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The BPA allows organizations to verify, hold, and issue verifiable credentials.
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -293,7 +293,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | global.ingressSuffix | string | `".stage.economyofthings.io"` | Domain suffix to be used for default hostpaths in ingress |
 | global.ledger | string | `"bosch-test"` | The used ledger. Will be used for default values. Any of: bosch-test, idu, bcovrin-test. |
 | global.nameOverride | string | `""` |  |
-| global.persistence.deployPostgres | bool | `true` | If true, the Postgres chart is deployed |
+| global.persistence.existingSecret | bool | `false` |  |
 | keycloak.clientId | string | `"<your keycloak client id>"` |  |
 | keycloak.clientSecret | string | `"<your keycloak client secret>"` |  |
 | keycloak.config.endsessionUrl | string | `"<your keycloak realm end session url>"` |  |
@@ -304,6 +304,8 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | keycloak.config.scopes | string | `"openid"` |  |
 | keycloak.enabled | bool | `false` |  |
 | postgresql.containerSecurityContext.enabled | bool | `true` |  |
+| postgresql.enabled | bool | `true` | If true, the Postgres chart is deployed |
+| postgresql.fullnameOverride | string | `""` | If prostgres.enabled is set to false this can be used to set the postgresql dns name. defaults to Chart.Name-postgresql otherwise |
 | postgresql.image.tag | int | `12` |  |
 | postgresql.persistence | object | `{"enabled":false,"size":"1Gi","storageClass":"default"}` | Persistent Volume Storage configuration. ref: https://kubernetes.io/docs/user-guide/persistent-volumes |
 | postgresql.persistence.enabled | bool | `false` | Enable PostgreSQL persistence using Persistent Volume Claims. |
@@ -322,7 +324,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 ## Chart dependencies
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami/ | postgresql | 10.3.13 |
+| https://charts.bitnami.com/bitnami/ | postgresql | 10.16.2 |
 
 ## Chart development
 

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -293,7 +293,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | global.ingressSuffix | string | `".stage.economyofthings.io"` | Domain suffix to be used for default hostpaths in ingress |
 | global.ledger | string | `"bosch-test"` | The used ledger. Will be used for default values. Any of: bosch-test, idu, bcovrin-test. |
 | global.nameOverride | string | `""` |  |
-| global.persistence.existingSecret | bool | `false` |  |
+| global.persistence.existingSecret | bool | `false` | Name of existing secret to use for PostgreSQL passwords |
 | keycloak.clientId | string | `"<your keycloak client id>"` |  |
 | keycloak.clientSecret | string | `"<your keycloak client secret>"` |  |
 | keycloak.config.endsessionUrl | string | `"<your keycloak realm end session url>"` |  |

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -240,44 +240,6 @@ Create the name for the password secret key.
 {{- end -}}
 
 {{/*
-Create environment variables for database configuration.
-*/}}
-{{- define "global.externalDbConfig" -}}
-- name: DB_VENDOR
-  value: {{ .Values.global.persistence.dbVendor | quote }}
-{{- if eq .Values.global.persistence.dbVendor "POSTGRES" }}
-- name: POSTGRES_PORT_5432_TCP_ADDR
-  value: {{ .Values.global.persistence.dbHost | quote }}
-- name: POSTGRES_PORT_5432_TCP_PORT
-  value: {{ .Values.global.persistence.dbPort | quote }}
-- name: POSTGRES_USER
-  value: {{ .Values.global.persistence.dbUser | quote }}
-- name: POSTGRES_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ template "global.externalDbSecret" . }}
-      key: {{ include "global.dbPasswordKey" . | quote }}
-- name: POSTGRES_DATABASE
-  value: {{ .Values.global.persistence.dbName | quote }}
-{{- else if eq .Values.global.persistence.dbVendor "MYSQL" }}
-- name: MYSQL_PORT_3306_TCP_ADDR
-  value: {{ .Values.global.persistence.dbHost | quote }}
-- name: MYSQL_PORT_3306_TCP_PORT
-  value: {{ .Values.global.persistence.dbPort | quote }}
-- name: MYSQL_USER
-  value: {{ .Values.global.persistence.dbUser | quote }}
-- name: MYSQL_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ template "global.externalDbSecret" . }}
-      key: {{ include "global.dbPasswordKey" . | quote }}
-- name: MYSQL_DATABASE
-  value: {{ .Values.global.persistence.dbName | quote }}
-{{- end }}
-{{- end -}}
-
-
-{{/*
 Return JAVA_OPTS -Dmicronaut.config.files
 Always return application.yml add in other files if they are enabled.
 */}}

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -213,8 +213,13 @@ generate tails uploadUrl
 Create a default fully qualified app name for the postgres requirement.
 */}}
 {{- define "global.postgresql.fullname" -}}
-{{- $postgresContext := dict "Values" .Values.postgresql "Release" .Release "Chart" (dict "Name" "postgresql") -}}
-{{ template "postgresql.primary.fullname" $postgresContext }}
+  {{- if .Values.postgresql.enabled -}}
+    {{- $postgresContext := dict "Values" .Values.postgresql "Release" .Release "Chart" (dict "Name" "postgresql") -}}
+    {{ template "postgresql.primary.fullname" $postgresContext }}
+  {{- else -}}
+    {{- $fullname := default (printf "%s-postgresql" .Release.Name) .Values.postgresql.fullnameOverride -}}
+    {{- printf "%s" $fullname | trunc 63 -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -23,7 +23,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}
@@ -116,7 +115,6 @@ Selector acapy labels
 app.kubernetes.io/name: {{ include "global.fullname" . }}-acapy
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
 
 {{/*
 generate hosts if not overriden
@@ -223,24 +221,13 @@ Create a default fully qualified app name for the postgres requirement.
 {{- end -}}
 
 {{/*
-Create the name for the database secret.
-*/}}
-{{- define "global.externalDbSecret" -}}
-{{- if .Values.global.persistence.existingSecret -}}
-  {{- .Values.global.persistence.existingSecret -}}
-{{- else -}}
-  {{- template "global.fullname" . -}}-db
-{{- end -}}
-{{- end -}}
-
-{{/*
-Create the name for the password secret key.
+Create the name for the password secret key. TODO currently not used, either delete or migrate key generation to template function
 */}}
 {{- define "global.dbPasswordKey" -}}
 {{- if .Values.global.persistence.existingSecret -}}
   {{- .Values.global.persistence.existingSecretKey -}}
 {{- else -}}
-  password
+  postgresql-password
 {{- end -}}
 {{- end -}}
 
@@ -343,7 +330,6 @@ If ux is enabled, create a volume for the config maps
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 If schemas or ux is enabled, create a volume mounts for the config maps
 */}}
@@ -404,7 +390,6 @@ Set the Business Partner Agent name
 {{- $name -}}
 {{- end -}}
 
-
 {{/*
 Set the Business Partner Agent Browser Title value.
 */}}
@@ -418,4 +403,3 @@ Set the Business Partner Agent Browser Title value.
 {{- end -}}
 {{- $title -}}
 {{- end -}}
-

--- a/charts/bpa/templates/bpa_deployment.yaml
+++ b/charts/bpa/templates/bpa_deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "global.postgresql.fullname" . }}
+                  name: {{ template "global.fullname" . }}
                   key: postgresql-password
             {{- include "bpa.keycloak.secret.env.vars" . | nindent 12}}
             - name: JAVA_OPTS

--- a/charts/bpa/templates/bpa_deployment.yaml
+++ b/charts/bpa/templates/bpa_deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "global.fullname" . }}
+                  name: {{ template "global.postgresql.fullname" . }}
                   key: postgresql-password
             {{- include "bpa.keycloak.secret.env.vars" . | nindent 12}}
             - name: JAVA_OPTS

--- a/charts/bpa/templates/db_secret.yml
+++ b/charts/bpa/templates/db_secret.yml
@@ -1,5 +1,5 @@
 
-{{- if and (not .Values.global.persistence.deployPostgres) (not .Values.global.persistence.existingSecret) -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.global.persistence.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,5 +11,5 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  {{ template "global.dbPasswordKey" . }}: {{ .Values.global.persistence.dbPassword | b64enc | quote }}
+  postgresql-password: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
 {{- end -}}

--- a/charts/bpa/templates/db_secret.yml
+++ b/charts/bpa/templates/db_secret.yml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "global.fullname" . }}-db
+  name: {{ template "global.postgresql.fullname" . }}
   labels:
     app: {{ template "global.name" . }}
     chart: {{ template "global.chart" . }}

--- a/charts/bpa/values.schema.json
+++ b/charts/bpa/values.schema.json
@@ -478,7 +478,7 @@
                 "persistence": {
                     "type": "object",
                     "properties": {
-                        "deployPostgres": {
+                        "existingSecret": {
                             "type": "boolean"
                         }
                     }
@@ -526,6 +526,9 @@
         "postgresql": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "containerSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/bpa/values.schema.json
+++ b/charts/bpa/values.schema.json
@@ -529,6 +529,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "fullNameOverwrite": {
+                    "type": "string"
+                },
                 "containerSecurityContext": {
                     "type": "object",
                     "properties": {

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -10,8 +10,8 @@ global:
   ingressSuffix: .stage.economyofthings.io
 
   persistence:
-    # -- If true, the Postgres chart is deployed
-    deployPostgres: true
+    #-- Name of existing secret to use for PostgreSQL passwords
+    existingSecret: false
 
   # -- The used ledger. Will be used for default values. Any of: bosch-test, idu, bcovrin-test.
   ledger: bosch-test
@@ -353,6 +353,9 @@ acapy:
     logLevel: info
 
 postgresql:
+  # -- If true, the Postgres chart is deployed
+  enabled: false
+
   # --  PostgreSQL service configuration
   service:
     port: 5432

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -10,7 +10,7 @@ global:
   ingressSuffix: .stage.economyofthings.io
 
   persistence:
-    #-- Name of existing secret to use for PostgreSQL passwords
+    # -- Name of existing secret to use for PostgreSQL passwords
     existingSecret: false
 
   # -- The used ledger. Will be used for default values. Any of: bosch-test, idu, bcovrin-test.
@@ -354,7 +354,10 @@ acapy:
 
 postgresql:
   # -- If true, the Postgres chart is deployed
-  enabled: false
+  enabled: true
+
+  # -- If prostgres.enabled is set to false this can be used to set the postgresql dns name. defaults to Chart.Name-postgresql otherwise
+  fullnameOverride: ""
 
   # --  PostgreSQL service configuration
   service:


### PR DESCRIPTION
Cleaned up the chart so that the postgresql subchart is now really optional. If the property postgres.enabled is set to false a dns name needs to be set via postgres.fullnameOverride.