### PR TITLE
Feature: inject existing database

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The BPA allows organizations to verify, hold, and issue verifiable credentials.
 type: application
 
-version: 0.10.3
+version: 0.11.0
 appVersion: 0.10.0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"

--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The BPA allows organizations to verify, hold, and issue verifiable credentials.
 type: application
 
-version: 0.10.2
+version: 0.10.3
 appVersion: 0.10.0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The BPA allows organizations to verify, hold, and issue verifiable credentials.
 
-![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The BPA allows organizations to verify, hold, and issue verifiable credentials.
 
-![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
+![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.0](https://img.shields.io/badge/AppVersion-0.10.0-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 

--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -26,6 +26,40 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.acapy.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: acapy-provision
+          image: "{{ .Values.acapy.image.repository }}:{{ .Values.acapy.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.acapy.image.pullPolicy }}
+          args: [
+           "-c",
+           "{{ include "acapy.registerLedger" . }} \
+           sleep 15; \
+           aca-py provision \
+           --endpoint https://{{ include "acapy.host" . }} \
+           --wallet-type {{ .Values.acapy.staticArgs.walletType }} \
+           --wallet-storage-type 'postgres_storage' \
+           --wallet-name {{ .Values.postgresql.postgresqlDatabase }} \
+           --wallet-key '123' \
+           --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
+           --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \
+           --seed \"$(WALLET_SEED)\" \
+           --genesis-url '{{ include "bpa.ledgerBrowser" . }}/genesis' \
+           --log-level info \
+           "
+          ]
+          command:
+          - /bin/bash
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "global.postgresql.fullname" . }}
+                  key: postgresql-password
+            - name: WALLET_SEED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "acapy.fullname" . }}
+                  key: seed
       containers:
         - name: acapy
           securityContext:
@@ -34,9 +68,7 @@ spec:
           imagePullPolicy: {{ .Values.acapy.image.pullPolicy }}
           args: [
            "-c",
-           "{{ include "acapy.registerLedger" . }} \
-           sleep 15; \
-           aca-py start \
+           "aca-py start \
            --auto-provision \
            --arg-file acapy-static-args.yml \
            --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \
@@ -44,7 +76,7 @@ spec:
            --genesis-url '{{ include "bpa.ledgerBrowser" . }}/genesis' \
            --endpoint https://{{ include "acapy.host" . }} \
            --wallet-storage-type 'postgres_storage' \
-           --wallet-name 'mywallet' \
+           --wallet-name {{ .Values.postgresql.postgresqlDatabase }} \
            --wallet-key '123' \
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \

--- a/charts/bpa/templates/bpa_configmap.yaml
+++ b/charts/bpa/templates/bpa_configmap.yaml
@@ -16,6 +16,7 @@ data:
   ACAPY_ENDPOINT: {{ $acapyEndpoint | quote }}
   ACAPY_API_KEY: {{ .Values.acapy.adminURLApiKey | quote }}
   BPA_PG_URL: {{ include "bpa.pgUrl" . | quote }}
+  BPA_PG_SCHEMA: "bpa"
   POSTGRESQL_USER: {{ .Values.postgresql.postgresqlUsername | quote }}
   BPA_SECURITY_ENABLED: {{ .Values.bpa.config.security.enabled | quote }}
   BPA_LEDGER_BROWSER: {{ include "bpa.ledgerBrowser" . | quote }}


### PR DESCRIPTION
It is now possible to inject a database name to aca-py. Like this it is possible to share a preexisting db between aca-py and bpa.

Warning this is not backwards compatible., If you upgrade to 0.11 your data will be lost. I will fix this with a later release, probably 0.11.1 If you do not want to loose data wait with the upgrade.