### PR TITLE
fix seed generation and ledger registration

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,7 +3,7 @@ name: bpa
 description: The BPA allows organizations to verify, hold, and issue verifiable credentials.
 type: application
 
-version: 0.11.4
+version: 0.11.5
 appVersion: 0.11.0
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The BPA allows organizations to verify, hold, and issue verifiable credentials.
 
-![Version: 0.11.4](https://img.shields.io/badge/Version-0.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.11.5](https://img.shields.io/badge/Version-0.11.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -176,9 +176,9 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| acapy.adminURLApiKey | string | `"2f9729eef0be49608c1cffd49ee3cc4a"` |  |
+| acapy.adminURLApiKey | string | `"2f9729eef0be49608c1cffd49ee3cc4a"` | Please change: key used to protect acapy's admin endpoint |
 | acapy.affinity | object | `{}` |  |
-| acapy.agentSeed | string | `""` | The agent seed, 32 characters. Will be generated if not defined here |
+| acapy.agentSeed | string | `"5a7db011075444a19d9bcaed56ad624a"` | Please change: the agent seed, 32 characters e.g. a UUID without the dashes. If the ledger is bosch-test or bcovrin-test the seed will be registered automatically. In all other cases this needs to happen manually beforehand. |
 | acapy.fullnameOverride | string | `""` |  |
 | acapy.image.pullPolicy | string | `"IfNotPresent"` |  |
 | acapy.image.repository | string | `"bcgovimages/aries-cloudagent"` |  |
@@ -237,7 +237,7 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | acapy.tails.enabled | bool | `false` | Set to true to enable revocation (external tails server required) |
 | acapy.tails.uploadUrlOverride | string | `""` | Override the otherwise ledger-specifically generated upload URL of the external tails server |
 | acapy.tolerations | list | `[]` |  |
-| acapy.walletKey | string | `"123"` | Wallet encryption key, be aware that if this value is changed aca-py needs to be restarted with the '--wallet-rekey' param which is not mapped |
+| acapy.walletKey | string | `"123"` | Please change: Wallet encryption key, be aware that if this value is changed later aca-py needs to be restarted with the '--wallet-rekey' param which is not mapped |
 | bpa.affinity | object | `{}` |  |
 | bpa.config.bootstrap.password | string | `"changeme"` | Default password |
 | bpa.config.bootstrap.username | string | `"admin"` | The name of the default admin user |

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -295,10 +295,10 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | bpa.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | bpa.tolerations | list | `[]` |  |
-| global.fullnameOverride | string | `""` |  |
+| global.fullnameOverride | string | `""` | Hostname prefix to be used for default hostpaths in ingress |
 | global.ingressSuffix | string | `".stage.economyofthings.io"` | Domain suffix to be used for default hostpaths in ingress |
 | global.ledger | string | `"bosch-test"` | The used ledger. Will be used for default values. Any of: bosch-test, idu, bcovrin-test. |
-| global.nameOverride | string | `""` |  |
+| global.nameOverride | string | `""` | Hostname to be used for default hostpaths in ingress, prefixed with the charts name |
 | global.persistence.existingSecret | bool | `false` | Name of existing secret to use for PostgreSQL passwords |
 | keycloak.clientId | string | `"<your keycloak client id>"` |  |
 | keycloak.clientSecret | string | `"<your keycloak client secret>"` |  |

--- a/charts/bpa/templates/_helpers.tpl
+++ b/charts/bpa/templates/_helpers.tpl
@@ -194,24 +194,11 @@ Return true if a secret object should be created
 {{- end -}}
 
 {{/*
-Return seed
-*/}}
-{{- define "acapy.seed" -}}
-{{- if .Values.acapy.agentSeed -}}
-    {{- .Values.acapy.agentSeed -}}
-{{- else -}}
-    {{- randAlphaNum 32 -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return acapy initialization call
 */}}
 {{- define "acapy.registerLedger" -}}
 {{- if or (eq .Values.global.ledger "bosch-test") (eq .Values.global.ledger "bcovrin-test") -}}
 curl -d '{\"seed\":\"$(WALLET_SEED)\", \"role\":\"TRUST_ANCHOR\", \"alias\":\"{{ include "bpa.fullname" . }}\"}' -X POST {{ include "bpa.ledgerBrowser" . }}/register;
-{{- else if eq .Values.global.ledger "idu" -}}
-identifier=`curl --header 'Content-Type: application/json' -d '{\"seed\":\"$(WALLET_SEED)\", \"role\":\"ENDORSER\", \"send\":true}' -X POST node-agent-registrar.md.svc.cluster.local/register | tr { '\n' | tr , '\n' | tr } '\n' | grep \"identifier\" | awk  -F'\"' '{print $4}'`;
 {{- end -}}
 {{- end -}}
 
@@ -220,9 +207,7 @@ Return acapy label
 */}}
 {{- define "acapy.label" -}}
 {{- if .Values.acapy.labelOverride -}}
-    {{- .Values.acapy.labelOverride }}
-{{- else if eq .Values.global.ledger "idu" -}}
-$identifier   
+    {{- .Values.acapy.labelOverride }} 
 {{- else -}} 
     {{- .Release.Name }}     
 {{- end -}}

--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -49,7 +49,6 @@ spec:
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\",\"admin_account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"admin_password\":\"$(POSTGRES_PASSWORD)\"}' \
            --seed \"$(WALLET_SEED)\" \
-           --replace-public-did \
            --genesis-url '{{ include "bpa.ledgerBrowser" . }}/genesis' \
            --log-level info \
            "
@@ -76,7 +75,6 @@ spec:
           args: [
            "-c",
            "aca-py start \
-           --auto-provision \
            --arg-file acapy-static-args.yml \
            --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \
            --webhook-url http://{{ include "bpa.fullname" . }}:{{ .Values.bpa.service.port }}/log#{{ .Values.bpa.config.webhook.key }} \
@@ -87,9 +85,8 @@ spec:
            --wallet-key {{ .Values.acapy.walletKey }} \
            --wallet-storage-config '{\"url\":\"{{ include "global.postgresql.fullname" . }}:{{ .Values.postgresql.service.port }}\",\"max_connections\":5}' \
            --wallet-storage-creds '{\"account\":\"{{ .Values.postgresql.postgresqlUsername }}\",\"password\":\"$(POSTGRES_PASSWORD)\"}' \
-           --seed \"$(WALLET_SEED)\" \
            --admin '0.0.0.0' {{ .Values.acapy.service.adminPort }} \
-           --admin-insecure-mode \
+           --admin-api-key {{ .Values.acapy.adminURLApiKey }} \
            --label {{ $acapyLabel }} \
            {{- if .Values.acapy.tails.enabled }}
            --tails-server-base-url {{ include "acapy.tails.baseUrl" . }} \
@@ -115,11 +112,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "global.postgresql.fullname" . }}
                   key: postgresql-password
-            - name: WALLET_SEED
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "acapy.fullname" . }}
-                  key: seed
           livenessProbe:
             httpGet:
               path: /status/live

--- a/charts/bpa/templates/acapy_secret.yaml
+++ b/charts/bpa/templates/acapy_secret.yaml
@@ -10,5 +10,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  seed: {{ required ".Values.acapy.agentSeed is required" .Values.acapy.agentSeed }}
+  seed: {{ required ".Values.acapy.agentSeed is required" .Values.acapy.agentSeed | b64enc | quote }}
 {{- end -}}

--- a/charts/bpa/templates/acapy_secret.yaml
+++ b/charts/bpa/templates/acapy_secret.yaml
@@ -10,9 +10,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  {{ if (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)) -}}
-  seed: {{ index (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)).data "seed" }}
-  {{- else -}}
-  seed: {{  .Values.acapy.agentSeed | default  (randAlphaNum 32) | b64enc | quote }}
-  {{- end -}} 
+  seed: {{ required ".Values.acapy.agentSeed is required" .Values.acapy.agentSeed }}
 {{- end -}}

--- a/charts/bpa/templates/acapy_secret.yaml
+++ b/charts/bpa/templates/acapy_secret.yaml
@@ -10,5 +10,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
+  {{ if (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)) -}}
+  seed: {{ index (lookup "v1" "Secret" .Release.Namespace (include "acapy.fullname" .)).data "seed" }}
+  {{- else -}}
   seed: {{ required ".Values.acapy.agentSeed is required" .Values.acapy.agentSeed | b64enc | quote }}
+  {{- end -}} 
 {{- end -}}

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -3,7 +3,9 @@
 # Declare variables to be passed into your templates.
 
 global:
+  # -- Hostname to be used for default hostpaths in ingress, prefixed with the charts name
   nameOverride: ""
+  # -- Hostname prefix to be used for default hostpaths in ingress
   fullnameOverride: ""
 
   # -- Domain suffix to be used for default hostpaths in ingress

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -242,13 +242,14 @@ acapy:
     # --  Overrides the image tag whose default is the chart appVersion.
     tag: py36-1.16-1_0.7.4
 
+  # -- Please change: key used to protect acapy's admin endpoint
   adminURLApiKey: 2f9729eef0be49608c1cffd49ee3cc4a
 
 
-  # -- The agent seed, 32 characters. Will be generated if not defined here
-  agentSeed: ""
+  # -- Please change: the agent seed, 32 characters e.g. a UUID without the dashes. If the ledger is bosch-test or bcovrin-test the seed will be registered automatically. In all other cases this needs to happen manually beforehand.
+  agentSeed: "5a7db011075444a19d9bcaed56ad624a"
 
-  # -- Wallet encryption key, be aware that if this value is changed aca-py needs to be restarted with the '--wallet-rekey' param which is not mapped
+  # -- Please change: Wallet encryption key, be aware that if this value is changed later aca-py needs to be restarted with the '--wallet-rekey' param which is not mapped
   walletKey: "123"
 
   # -- Used for backwards compatibility

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -247,7 +247,7 @@ acapy:
 
 
   # -- Please change: the agent seed, 32 characters e.g. a UUID without the dashes. If the ledger is bosch-test or bcovrin-test the seed will be registered automatically. In all other cases this needs to happen manually beforehand.
-  agentSeed: "5a7db011075444a19d9bcaed56ad624a"
+  agentSeed: 5a7db011075444a19d9bcaed56ad624a
 
   # -- Please change: Wallet encryption key, be aware that if this value is changed later aca-py needs to be restarted with the '--wallet-rekey' param which is not mapped
   walletKey: "123"


### PR DESCRIPTION
see: https://github.com/hyperledger-labs/business-partner-agent-chart/issues/53

- removed automatic seed generation.
- had to keep a default value, because otherwise the tests will not run anymore. 
- set acapy admin key. 
- removed not needed acapy start params.
- removed idu ledger registration because it is not portable

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>