### PR TITLE
use websocket for aca-py events instead of webhook

### DIFF
--- a/charts/bpa/Chart.yaml
+++ b/charts/bpa/Chart.yaml
@@ -3,8 +3,8 @@ name: bpa
 description: The BPA allows organizations to verify, hold, and issue verifiable credentials.
 type: application
 
-version: 0.11.6
-appVersion: sha-cde75be
+version: 0.11.7
+appVersion: sha-1c45cf8
 
 home: "https://github.com/hyperledger-labs/business-partner-agent-chart"
 sources: ["https://github.com/hyperledger-labs/business-partner-agent-chart"]

--- a/charts/bpa/README.md
+++ b/charts/bpa/README.md
@@ -2,7 +2,7 @@
 
 The BPA allows organizations to verify, hold, and issue verifiable credentials.
 
-![Version: 0.11.6](https://img.shields.io/badge/Version-0.11.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-cde75be](https://img.shields.io/badge/AppVersion-sha--cde75be-informational?style=flat-square)
+![Version: 0.11.7](https://img.shields.io/badge/Version-0.11.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: sha-1c45cf8](https://img.shields.io/badge/AppVersion-sha--1c45cf8-informational?style=flat-square)
 
 The Business Partner Agent allows to manage and exchange master data between organizations.
 
@@ -266,7 +266,6 @@ Note: Deleting the PVC's will delete postgresql data as well. Please be cautious
 | bpa.config.security.strict | bool | `true` | Enable strict strict security headers |
 | bpa.config.titleOverride | string | `""` | Override title shown in the browser tab. Default: Helm release name, capitalized (or NameOverride if given) |
 | bpa.config.web.only | bool | `false` |  |
-| bpa.config.webhook.key | string | `"changeme"` | Optional: secures aca-py to backend webhook communication with an api-key |
 | bpa.image.pullPolicy | string | `"IfNotPresent"` |  |
 | bpa.image.repository | string | `"ghcr.io/hyperledger-labs/business-partner-agent-new"` |  |
 | bpa.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/bpa/templates/acapy_deployment.yaml
+++ b/charts/bpa/templates/acapy_deployment.yaml
@@ -77,7 +77,6 @@ spec:
            "aca-py start \
            --arg-file acapy-static-args.yml \
            --inbound-transport http '0.0.0.0' {{ .Values.acapy.service.httpPort }} \
-           --webhook-url http://{{ include "bpa.fullname" . }}:{{ .Values.bpa.service.port }}/log#{{ .Values.bpa.config.webhook.key }} \
            --genesis-transactions-list genesis-transaction-list.yaml \
            --endpoint https://{{ include "acapy.host" . }} \
            --wallet-storage-type 'postgres_storage' \

--- a/charts/bpa/templates/bpa_configmap.yaml
+++ b/charts/bpa/templates/bpa_configmap.yaml
@@ -31,7 +31,6 @@ data:
   BPA_TITLE: {{ $browserTitle | quote }}
   BPA_I18N_LOCALE: {{ .Values.bpa.config.i18n.locale | quote }}
   BPA_I18N_FALLBACK_LOCALE: {{ .Values.bpa.config.i18n.fallbackLocale | quote }}
-  BPA_WEBHOOK_KEY: {{ .Values.bpa.config.webhook.key | quote }}
 {{- if .Values.bpa.config.imprint.enabled }}
   BPA_IMPRINT_URL: {{ .Values.bpa.config.imprint.urlOverride | default (printf "https://bpa%s/" .Values.global.ingressSuffix) | quote }}
 {{- end }}   

--- a/charts/bpa/values.yaml
+++ b/charts/bpa/values.yaml
@@ -55,9 +55,6 @@ bpa:
       username: admin
       # -- Default password
       password: changeme
-    webhook:
-      # -- Optional: secures aca-py to backend webhook communication with an api-key
-      key: changeme
     ledger:
       browserUrlOverride: ""
     # -- The scheme that is used to register the profile endpoint on the ledger


### PR DESCRIPTION
latest bpa image with performance fixes and switch to websocket

Signed-off-by: Philipp Etschel <philipp.etschel@ch.bosch.com>